### PR TITLE
Fix bug with clear() as reported in #750

### DIFF
--- a/src/js/form-render.js
+++ b/src/js/form-render.js
@@ -280,8 +280,12 @@ class FormRender {
         .filter(fieldData => fieldData.subtype === 'tinymce')
         .forEach(fieldData => window.tinymce.get(fieldData.name).setContent(''))
       container.querySelectorAll('input, select, textarea').forEach(input => {
-        input.value = ''
-        input.checked = false
+        if (input.type === 'checkbox' || input.type === 'radio') {
+          input.checked = false;
+        }
+        else {
+          input.value = '';
+        }
       })
     })
   }


### PR DESCRIPTION
Add control type check to clear() so that method doesn't reset the value for checkboxes and radio buttons, which caused the userData getter to work incorrectly.

See https://github.com/kevinchappell/formBuilder/pull/750#issuecomment-426801472 for more.